### PR TITLE
Customize confluence postmortem template

### DIFF
--- a/backend/bot/audit/log.py
+++ b/backend/bot/audit/log.py
@@ -1,6 +1,6 @@
 from bot.models.pg import AuditLog, Session
 from bot.shared import tools
-from bot.slack.client import get_user_name
+from bot.slack.client import get_slack_user
 from iblog import logger
 from sqlalchemy import update
 from sqlalchemy.orm import scoped_session
@@ -138,7 +138,7 @@ def write(
         data.append(
             {
                 "log": event,
-                "user": get_user_name(user),
+                "user": get_slack_user(user)['real_name'],
                 "content": content,
                 "ts": ts if ts != "" else tools.fetch_timestamp(),
             }

--- a/backend/bot/confluence/api.py
+++ b/backend/bot/confluence/api.py
@@ -1,18 +1,86 @@
+from typing import Literal
+import requests
+import atlassian.errors
 import config
-import datetime
 
 from atlassian import Confluence
+from atlassian.errors import ApiPermissionError
 from iblog import logger
 
 
 class ConfluenceApi:
-    def __init__(self):
-        self.confluence = Confluence(
+    def __init__(self, confluence: Confluence | None = None) -> None:
+        self.confluence = confluence or Confluence(
             url=config.atlassian_api_url,
             username=config.atlassian_api_username,
             password=config.atlassian_api_token,
             cloud=True,
         )
+
+    def fetch_template_body(self, template_id: int) -> str | None:
+        """Fetches the body of a Confluence template"""
+        try:
+            response = self.confluence.get_content_template(template_id)
+        except atlassian.errors.ApiError as error:
+            logger.error(f"Could not find template with id: {template_id}")
+            return None
+        except requests.HTTPError as error:
+            logger.error(f"Error fetching template body from confluence: {error}")
+            return None
+        return response["body"]["storage"]["value"]
+
+    def create_page(
+        self,
+        space: str,
+        title: str,
+        body: str,
+        parent_id: str | None= None,
+        type: str = "page",
+        representation: str="storage",
+        editor: str | None = None,
+        full_width: bool=False,
+        labels: list[str] | None = None,
+        status: Literal['draft'] | None = None,
+    ) -> dict:
+        """
+        Unfortunately the atlassian-python-api does not support creating pages
+        with labels or any other advanced features. This method is a copy and paste with a few workarounds.
+        """
+        url = "rest/api/content/"
+        data = {
+            "type": type,
+            "title": title,
+            "status": status,
+            "space": {"key": space},
+            "body": self.api._create_body(body, representation),
+            "metadata": {"properties": {}},
+        }
+        if parent_id:
+            data["ancestors"] = [{"type": type, "id": parent_id}]
+        if editor is not None and editor in ["v1", "v2"]:
+            data["metadata"]["properties"]["editor"] = {"value": editor}
+        if full_width is True:
+            data["metadata"]["properties"]["content-appearance-draft"] = {"value": "full-width"}
+            data["metadata"]["properties"]["content-appearance-published"] = {"value": "full-width"}
+        else:
+            data["metadata"]["properties"]["content-appearance-draft"] = {"value": "fixed-width"}
+            data["metadata"]["properties"]["content-appearance-published"] = {"value": "fixed-width"}
+
+        # https://community.atlassian.com/t5/Answers-Developer-Questions/Creating-a-confluence-page-via-rest-api-with-a-label/qaq-p/469849
+        if labels:
+            data["metadata"]["labels"] = [{"name": label} for label in labels]
+
+        try:
+            response = self.api.post(url, data=data)
+        except atlassian.errors.HTTPError as e:
+            if e.response.status_code == 404:
+                raise ApiPermissionError(
+                    "The calling user does not have permission to view the content",
+                    reason=e,
+                )
+
+            raise
+        return response
 
     @property
     def api(self) -> Confluence:
@@ -31,5 +99,6 @@ class ConfluenceApi:
         except Exception as error:
             logger.error(f"Error authenticating to Confluence: {error}")
             logger.error(
-                f"Please check Confluence configuration and try again."
+                "Please check Confluence configuration and try again."
             )
+        return False

--- a/backend/bot/confluence/postmortem.py
+++ b/backend/bot/confluence/postmortem.py
@@ -1,5 +1,6 @@
 import datetime
 import config
+from bot.slack.client import get_slack_user, slack_workspace_id
 
 from bot.confluence.api import ConfluenceApi, logger
 from bot.models.pg import IncidentLogging

--- a/backend/bot/exc.py
+++ b/backend/bot/exc.py
@@ -20,3 +20,11 @@ class IndexNotFoundError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
+
+class PostmortemException(Exception):
+    """Exceptions raised during postmortem creation"""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)

--- a/backend/bot/incident/actions.py
+++ b/backend/bot/incident/actions.py
@@ -404,7 +404,9 @@ async def set_status(
                 .get("confluence")
                 .get("auto_create_postmortem")
             ):
-                postmortem_link = await create_post_mortem_block(incident_data, incident_commander=actual_user_names[0])
+                postmortem_link = await create_post_mortem_block(
+                    incident_data, incident_commander=actual_user_names[0]
+                )
         # Send message to incident channel
         try:
             result = slack_web_client.chat_postMessage(
@@ -442,15 +444,17 @@ async def set_status(
                 status=action_value,
                 severity=incident_data.severity,
                 conference_bridge=incident_data.conference_bridge,
-                postmortem_link=postmortem_link
-                if action_value == "resolved"
-                and ("atlassian" in config.active.integrations)
-                and (
-                    config.active.integrations.get("atlassian")
-                    .get("confluence")
-                    .get("auto_create_postmortem")
-                )
-                else None,
+                postmortem_link=(
+                    postmortem_link
+                    if action_value == "resolved"
+                    and ("atlassian" in config.active.integrations)
+                    and (
+                        config.active.integrations.get("atlassian")
+                        .get("confluence")
+                        .get("auto_create_postmortem")
+                    )
+                    else None
+                ),
             ),
             text="",
         )
@@ -587,7 +591,9 @@ async def set_status(
     )
 
 
-async def create_post_mortem_block(incident_data: Incident, incident_commander: str) -> str | None:
+async def create_post_mortem_block(
+    incident_data: Incident, incident_commander: str
+) -> str | None:
     """Generates a postmortem template and creates the postmortem"""
     from bot.confluence.postmortem import IncidentPostmortem
 
@@ -682,6 +688,7 @@ async def create_post_mortem_block(incident_data: Incident, incident_commander: 
             f"Error sending postmortem update to incident channel: {error}"
         )
     return postmortem_link
+
 
 async def set_severity(
     action_parameters: type[ActionParametersSlack] = None,

--- a/backend/bot/incident/incident.py
+++ b/backend/bot/incident/incident.py
@@ -1,8 +1,10 @@
 import asyncio
-import config
 import re
-import slack_sdk.errors
+from datetime import datetime
+from typing import Dict
 
+import config
+import slack_sdk.errors
 from bot.audit import log
 from bot.exc import ConfigurationError
 from bot.models.incident import (
@@ -26,9 +28,7 @@ from bot.templates.incident.digest_notification import (
 )
 from bot.zoom.meeting import ZoomMeeting
 from cerberus import Validator
-from datetime import datetime
 from iblog import logger
-from typing import Dict
 
 # How many total characters are allowed in a Slack channel name?
 # Limit the channel name to 76 to take this into account

--- a/backend/bot/jira/issue.py
+++ b/backend/bot/jira/issue.py
@@ -23,7 +23,9 @@ class JiraIssue:
         self.description = description
         self.issue_type = issue_type
         self.labels = (
-            config.active.integrations.get("atlassian").get("jira").get("labels")
+            config.active.integrations.get("atlassian")
+            .get("jira")
+            .get("labels")
         ) + [self.incident_data.channel_name]
         # self.priority = priority
         self.summary = summary

--- a/backend/bot/shared/tools.py
+++ b/backend/bot/shared/tools.py
@@ -18,6 +18,10 @@ timestamp_fmt_short = "%d/%m/%Y %H:%M:%S %Z"
 
 application_timezone = config.active.options.get("timezone")
 
+def parse_timestamp(timestamp_string: str) -> datetime:
+    """Parses a '2024-02-13T20:52:58 AEDT' formatted string to a datetime object with timezone"""
+    return datetime.strptime(timestamp_string, timestamp_fmt).astimezone(timezone(application_timezone))
+
 
 def fetch_timestamp(short: bool = False):
     """Return a localized, formatted timestamp using datetime.now()"""

--- a/backend/bot/slack/client.py
+++ b/backend/bot/slack/client.py
@@ -352,9 +352,9 @@ def check_user_in_group(user_id: str, group_name: str) -> bool:
         )
 
 
-def get_user_name(user_id: str) -> str:
+def get_slack_user(user_id: str) -> dict | None:
     """
-    Get a single user's real_name from a user ID
+    Get a single user from a user ID
 
     This is done against the local database so it won't work unless the job to store
     slack user data has been run
@@ -362,9 +362,8 @@ def get_user_name(user_id: str) -> str:
     ulist = Session.query(OperationalData).filter_by(id="slack_users").one()
     for obj in ulist.json_data:
         if user_id in obj.values():
-            return obj["real_name"]
-        else:
-            continue
+            return obj
+    return None
 
 
 def get_slack_users() -> List[Dict[str, Any]]:

--- a/backend/bot/slack/client.py
+++ b/backend/bot/slack/client.py
@@ -392,6 +392,7 @@ def get_slack_users() -> List[Dict[str, Any]]:
         {
             "name": user["name"],
             "real_name": user["profile"]["real_name"],
+            "email": user['profile'].get("email"), # this requires user:read.email scope
             "id": user["id"],
         }
         for user in users

--- a/backend/bot/slack/handler.py
+++ b/backend/bot/slack/handler.py
@@ -15,7 +15,7 @@ from bot.models.pager import read_pager_auto_page_targets
 from bot.scheduler import scheduler
 from bot.shared import tools
 from bot.slack.client import (
-    get_user_name,
+    get_slack_user,
     slack_web_client,
     slack_workspace_id,
 )
@@ -543,7 +543,7 @@ def reaction_added(event, say):
                                 img=res.content,
                                 mimetype=file["mimetype"],
                                 ts=tools.fetch_timestamp(short=True),
-                                user=get_user_name(user_id=message["user"]),
+                                user=get_slack_user(user_id=message["user"]["real_name"]),
                             )
                             # Revoke public access
                             try:
@@ -582,7 +582,7 @@ def reaction_added(event, say):
                         incident_id=channel_info["channel"]["name"],
                         content=message["text"],
                         ts=tools.fetch_timestamp(short=True),
-                        user=get_user_name(user_id=message["user"]),
+                        user=get_slack_user(user_id=message["user"]["real_name"]),
                     )
             except Exception as error:
                 logger.error(

--- a/backend/bot/templates/confluence/postmortem.py
+++ b/backend/bot/templates/confluence/postmortem.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import TypedDict
 
 
 default_template = """
@@ -126,24 +127,37 @@ default_template = """
 <ac:structured-macro ac:name="attachments" ac:schema-version="1" data-layout="wide"
   ac:local-id="{uuid}" ac:macro-id="{uuid}" />
 """
+
+
+class PostmortemContext(TypedDict):
+    incident_id: str
+    incident_commander: str | None
+    severity: str | None
+    severity_html: str | None
+    severity_definition: str | None
+    timeline_html: str | None
+    pinned_messages_html: str | None
+    author: str | None
+    incident_date: str | None
+    postmortem_date: str | None
+    roles_html: str | None
+    description: str | None
+
+
 class PostmortemTemplate:
     @staticmethod
     def template(
-        incident_commander: str,
-        severity: str,
-        severity_definition: str,
-        timeline: str,
-        pinned_messages: str,
+        context: PostmortemContext,
         template_body: str | None = None,
     ):
         template_body = template_body or default_template
         # For each {uuid} replace with a new uuid.uuid4()
         while "{uuid}" in template_body:
-            template_body = template_body.replace("{uuid}", str(uuid.uuid4()), 1)
-        return template_body.format(
-            incident_commander=incident_commander,
-            severity=severity,
-            severity_definition=severity_definition,
-            timeline=timeline,
-            pinned_messages=pinned_messages,
-        )
+            template_body = template_body.replace(
+                "{uuid}", str(uuid.uuid4()), 1
+            )
+
+        for k, v in context.items():
+            if v is not None:
+                template_body = template_body.replace(f"{{{k}}}", str(v))
+        return template_body

--- a/backend/bot/templates/confluence/postmortem.py
+++ b/backend/bot/templates/confluence/postmortem.py
@@ -68,23 +68,7 @@ default_template = """
 </ac:structured-macro>
 
 <h1>Timeline</h1>
-<table data-layout="default" ac:local-id="{uuid}">
-  <colgroup>
-    <col style="width: 340.0px;" />
-    <col style="width: 340.0px;" />
-  </colgroup>
-  <tbody>
-    <tr>
-      <td data-highlight-colour="#f4f5f7">
-        <p><strong>Time</strong></p>
-      </td>
-      <td data-highlight-colour="#f4f5f7">
-        <p><strong>Event</strong></p>
-      </td>
-    </tr>
-    {timeline}
-  </tbody>
-</table>
+{timeline_table_html}
 
 <h1>Incident Description</h1>
 <ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
@@ -123,7 +107,7 @@ default_template = """
     <p>This information is useful for establishing the incident timeline and providing diagnostic data.</p>
   </ac:rich-text-body>
 </ac:structured-macro>
-{pinned_messages}
+{pinned_messages_html}
 <ac:structured-macro ac:name="attachments" ac:schema-version="1" data-layout="wide"
   ac:local-id="{uuid}" ac:macro-id="{uuid}" />
 """
@@ -133,15 +117,15 @@ class PostmortemContext(TypedDict):
     incident_id: str
     incident_commander: str | None
     severity: str | None
-    severity_html: str | None
     severity_definition: str | None
-    timeline_html: str | None
+    timeline_table_html: str | None
     pinned_messages_html: str | None
     author: str | None
     incident_date: str | None
     postmortem_date: str | None
     roles_html: str | None
     description: str | None
+    channel_link: str | None
 
 
 class PostmortemTemplate:

--- a/backend/bot/templates/confluence/postmortem.py
+++ b/backend/bot/templates/confluence/postmortem.py
@@ -134,12 +134,13 @@ class PostmortemTemplate:
         severity_definition: str,
         timeline: str,
         pinned_messages: str,
-        template_str: str = default_template,
+        template_body: str | None = None,
     ):
+        template_body = template_body or default_template
         # For each {uuid} replace with a new uuid.uuid4()
-        while "{uuid}" in template_str:
-            template_str = template_str.replace("{uuid}", str(uuid.uuid4()), 1)
-        return template_str.format(
+        while "{uuid}" in template_body:
+            template_body = template_body.replace("{uuid}", str(uuid.uuid4()), 1)
+        return template_body.format(
             incident_commander=incident_commander,
             severity=severity,
             severity_definition=severity_definition,

--- a/backend/bot/templates/confluence/postmortem.py
+++ b/backend/bot/templates/confluence/postmortem.py
@@ -1,17 +1,8 @@
 import uuid
 
 
-class PostmortemTemplate:
-    @staticmethod
-    def template(
-        incident_commander: str,
-        severity: str,
-        severity_definition: str,
-        timeline: str,
-        pinned_messages: str,
-    ):
-        return f"""
-<table data-layout="default" ac:local-id="{str(uuid.uuid4())}">
+default_template = """
+<table data-layout="default" ac:local-id="{uuid}">
   <colgroup>
     <col style="width: 340.0px;" />
     <col style="width: 340.0px;" />
@@ -46,21 +37,21 @@ class PostmortemTemplate:
 
 <h2>Summary</h2>
 
-<ac:structured-macro ac:name="info" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="info" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>This incident was classified as a <b>{severity}</b> incident.</p>
     <p>{severity_definition}</p>
   </ac:rich-text-body>
 </ac:structured-macro>
 
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>A summary of the impact of this incident should go here.</p>
   </ac:rich-text-body>
 </ac:structured-macro>
 
 <h2>User Impact</h2>
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>Describe how this incident affected users. Summarize answers to these two questions:</p>
     <ul>
@@ -76,7 +67,7 @@ class PostmortemTemplate:
 </ac:structured-macro>
 
 <h1>Timeline</h1>
-<table data-layout="default" ac:local-id="{str(uuid.uuid4())}">
+<table data-layout="default" ac:local-id="{uuid}">
   <colgroup>
     <col style="width: 340.0px;" />
     <col style="width: 340.0px;" />
@@ -95,14 +86,14 @@ class PostmortemTemplate:
 </table>
 
 <h1>Incident Description</h1>
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>Longer description of the problem with screenshots/links to help readers understand the entire incident.</p>
   </ac:rich-text-body>
 </ac:structured-macro>
 
 <h1>Root Cause</h1>
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>Explain the root cause of the issue.</p>
   </ac:rich-text-body>
@@ -111,21 +102,21 @@ class PostmortemTemplate:
 <h1>Actions</h1>
 
 <h2>Immediate Actions</h2>
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>Actions to mitigate the impact of the incident directly following declaration should be listed here.</p>
   </ac:rich-text-body>
 </ac:structured-macro>
 
 <h2>Preventive Actions</h2>
-<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="note" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>What can be implemented to avoid this condition in the future?</p>
   </ac:rich-text-body>
 </ac:structured-macro>
 
 <h1>Pinned Messages</h1>
-<ac:structured-macro ac:name="info" ac:schema-version="1" ac:macro-id="{str(uuid.uuid4())}">
+<ac:structured-macro ac:name="info" ac:schema-version="1" ac:macro-id="{uuid}">
   <ac:rich-text-body>
     <p>These messages were pinned during the incident by users in Slack.</p>
     <p>This information is useful for establishing the incident timeline and providing diagnostic data.</p>
@@ -133,5 +124,25 @@ class PostmortemTemplate:
 </ac:structured-macro>
 {pinned_messages}
 <ac:structured-macro ac:name="attachments" ac:schema-version="1" data-layout="wide"
-  ac:local-id="{str(uuid.uuid4())}" ac:macro-id="{str(uuid.uuid4())}" />
+  ac:local-id="{uuid}" ac:macro-id="{uuid}" />
 """
+class PostmortemTemplate:
+    @staticmethod
+    def template(
+        incident_commander: str,
+        severity: str,
+        severity_definition: str,
+        timeline: str,
+        pinned_messages: str,
+        template_str: str = default_template,
+    ):
+        # For each {uuid} replace with a new uuid.uuid4()
+        while "{uuid}" in template_str:
+            template_str = template_str.replace("{uuid}", str(uuid.uuid4()), 1)
+        return template_str.format(
+            incident_commander=incident_commander,
+            severity=severity,
+            severity_definition=severity_definition,
+            timeline=timeline,
+            pinned_messages=pinned_messages,
+        )

--- a/backend/config.py
+++ b/backend/config.py
@@ -229,6 +229,11 @@ class Configuration:
                                         "type": "string",
                                         "empty": False,
                                     },
+                                    "postmortem_template_id": {
+                                        "required": False,
+                                        "type": "integer",
+                                        "empty": False,
+                                    }
                                 },
                             },
                             "jira": {
@@ -605,7 +610,7 @@ Core functionality:
     Slack workspace:                    {workspace}
     Logging level:                      {log_level}
 
-Integrations Configuration:                           
+Integrations Configuration:
 {json.dumps(active.integrations, sort_keys=True, indent=4)}
 --------------------------------------------------------------------------------
     """

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -92,6 +92,8 @@ integrations:
   #   auto_create_postmortem: true
   #   space: ENGINEERIN
   #   parent: Postmortems
+  #   # Set a jira template to use for postmortems.
+  #   postmortem_template_id: 163984
   # Enable Jira integration
   # jira:
   #   project: 'IN'

--- a/backend/tests/test_postmortem.py
+++ b/backend/tests/test_postmortem.py
@@ -8,7 +8,7 @@ from bot.templates.confluence.postmortem import PostmortemTemplate
 
 class TestPostMortem:
     def test_template_replacement_uuid(self):
-        template_str = "{uuid}"
+        template_body = "{uuid}"
 
         result = PostmortemTemplate.template(
             incident_commander="",
@@ -16,13 +16,13 @@ class TestPostMortem:
             severity_definition="",
             timeline="",
             pinned_messages="",
-            template_str=template_str,
+            template_body=template_body,
         )
 
         assert uuid.UUID(result), "{uuid} was not replaced with a valid UUID"
 
     def test_template_replaces_each_uuid_with_unique_uuid(self):
-        template_str = "{uuid}\n{uuid}"
+        template_body = "{uuid}\n{uuid}"
 
         result = PostmortemTemplate.template(
             incident_commander="",
@@ -30,7 +30,7 @@ class TestPostMortem:
             severity_definition="",
             timeline="",
             pinned_messages="",
-            template_str=template_str,
+            template_body=template_body,
         )
 
         assert (

--- a/backend/tests/test_postmortem.py
+++ b/backend/tests/test_postmortem.py
@@ -35,9 +35,9 @@ class TestPostMortem:
                 incident_commander="INCIDENT_COMMANDER",
                 severity="SEV1",
                 severity_definition="SEV1_DESCRIPTION",
-                timeline_html="TIMELINE",
+                timeline_table_html="TIMELINE",
+                pinned_messages_html="PINNED_MESSAGES",
             ),
-            pinned_messages="PINNED_MESSAGES",
         )
 
         assert "INCIDENT_COMMANDER" in result

--- a/backend/tests/test_postmortem.py
+++ b/backend/tests/test_postmortem.py
@@ -3,7 +3,7 @@ import uuid
 
 from bot.shared import tools
 from bot.confluence.postmortem import IncidentPostmortem
-from bot.templates.confluence.postmortem import PostmortemTemplate
+from bot.templates.confluence.postmortem import PostmortemTemplate, PostmortemContext
 
 
 class TestPostMortem:
@@ -11,11 +11,7 @@ class TestPostMortem:
         template_body = "{uuid}"
 
         result = PostmortemTemplate.template(
-            incident_commander="",
-            severity="",
-            severity_definition="",
-            timeline="",
-            pinned_messages="",
+            context=PostmortemContext(),
             template_body=template_body,
         )
 
@@ -25,11 +21,7 @@ class TestPostMortem:
         template_body = "{uuid}\n{uuid}"
 
         result = PostmortemTemplate.template(
-            incident_commander="",
-            severity="",
-            severity_definition="",
-            timeline="",
-            pinned_messages="",
+            context=PostmortemContext(),
             template_body=template_body,
         )
 
@@ -39,10 +31,12 @@ class TestPostMortem:
 
     def test_default_template(self):
         result = PostmortemTemplate.template(
-            incident_commander="INCIDENT_COMMANDER",
-            severity="SEV1",
-            severity_definition="SEV1_DESCRIPTION",
-            timeline="TIMELINE",
+            context=PostmortemContext(
+                incident_commander="INCIDENT_COMMANDER",
+                severity="SEV1",
+                severity_definition="SEV1_DESCRIPTION",
+                timeline_html="TIMELINE",
+            ),
             pinned_messages="PINNED_MESSAGES",
         )
 

--- a/backend/tests/test_postmortem.py
+++ b/backend/tests/test_postmortem.py
@@ -1,0 +1,53 @@
+import datetime
+import uuid
+
+from bot.shared import tools
+from bot.confluence.postmortem import IncidentPostmortem
+from bot.templates.confluence.postmortem import PostmortemTemplate
+
+
+class TestPostMortem:
+    def test_template_replacement_uuid(self):
+        template_str = "{uuid}"
+
+        result = PostmortemTemplate.template(
+            incident_commander="",
+            severity="",
+            severity_definition="",
+            timeline="",
+            pinned_messages="",
+            template_str=template_str,
+        )
+
+        assert uuid.UUID(result), "{uuid} was not replaced with a valid UUID"
+
+    def test_template_replaces_each_uuid_with_unique_uuid(self):
+        template_str = "{uuid}\n{uuid}"
+
+        result = PostmortemTemplate.template(
+            incident_commander="",
+            severity="",
+            severity_definition="",
+            timeline="",
+            pinned_messages="",
+            template_str=template_str,
+        )
+
+        assert (
+            result.split()[0] != result.split()[1]
+        ), "{uuid} was not replaced with a unique UUID"
+
+    def test_default_template(self):
+        result = PostmortemTemplate.template(
+            incident_commander="INCIDENT_COMMANDER",
+            severity="SEV1",
+            severity_definition="SEV1_DESCRIPTION",
+            timeline="TIMELINE",
+            pinned_messages="PINNED_MESSAGES",
+        )
+
+        assert "INCIDENT_COMMANDER" in result
+        assert "SEV1" in result
+        assert "SEV1_DESCRIPTION" in result
+        assert "PINNED_MESSAGES" in result
+        assert "TIMELINE" in result

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -27,6 +27,7 @@ integrations:
       auto_create_postmortem: true
       space: ENG
       parent: Postmortems
+      postmortem_template_id: 123123
     jira:
       project: INCMGMT
       issue_types: ['Task', 'Epic', 'Story']
@@ -46,7 +47,22 @@ If you use the pinned items feature, those will automatically be added to the do
 
 There is also a timeline feature accessible using the `/timeline` shortcut in Slack.
 
-All fields are **required** for this section.
+All fields are **required** for this section with the exception of `postmortem_template_id`. Set `postmortem_template_id` to the id of an existing **custom jira template** in your workspace to use a custom template for postmortems.
+
+Template variables available:
+| Key  | Description |
+|---|---|
+| {incident_id}  | The id of the incident  |
+| {incident_commander}  | A confluence link to the incident_commander|
+| {incident_date}  | Date of the incident |
+| {severity}  | Severity of the incident |
+| {severity_definition}  | The definition of the severity |
+| {timeline_table_html}  | A table with with two columns: timestamps and timeline events|
+| {pinned_messages_html}  | A block containing all the pinned messages|
+| {roles_html}  | Each role and the person assigned. |
+| {description}  | The channel description|
+| {channel_link}  | A html link to the slack channel|
+
 
 ### Using the Jira Integration
 
@@ -88,7 +104,7 @@ You can integrate with Opsgenie to create incidents. To start, you'll need an AP
 
 !!! warning
 
-    If you're using Opsgenie's **Free** or **Essentials** plan or if you’re using Opsgenie with Jira Service Management's Standard plan, you can add this integration from your team dashboard only. The Integrations page under Settings is not available in your plan. 
+    If you're using Opsgenie's **Free** or **Essentials** plan or if you’re using Opsgenie with Jira Service Management's Standard plan, you can add this integration from your team dashboard only. The Integrations page under Settings is not available in your plan.
 
 In short, you can only create an API integration for a team if on one of these plans. The drop down when creating an alert will only ever show this team as the recipient. If you wish to use more than one team, you will need to upgrade to a compatible plan and provide an organization-wide key.
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -53,6 +53,7 @@ oauth_config:
       - reactions:write
       - usergroups:read
       - users:read
+      - users:read.email
 settings:
   event_subscriptions:
     bot_events:


### PR DESCRIPTION
## Describe your changes

I've added a couple of things to allow a custom jira template be used for postmortems.

```
integrations:
  confluence:
    postmortem_template_id: 163984
```

By setting the postmortem_template_id, the template will be fetched and updated in a fashion similar to jinja. Text on the page (including the title) will be replaced if it matches a variable in the context.

```
class PostmortemContext(TypedDict):
    incident_id: str
    incident_commander: str | None
    severity: str | None
    severity_definition: str | None
    timeline_table_html: str | None
    pinned_messages_html: str | None
    author: str | None
    incident_date: str | None
    postmortem_date: str | None
    roles_html: str | None
    description: str | None
    channel_link: str | None
```

- This change also creates the links from slack users -> confluence users within the post mortem.
- Slack user emails are now fetched and stored in `opsdata`, this requires a **manifest update / app reinstallation**  to work.

## Issue number and link
Closes https://github.com/echoboomer/incident-bot/issues/419.


## Checklist before requesting a review

- [ ] I have properly bumped all version refs by running `./scripts/version-bump.sh v<new>` from project root - for example `./scripts/version-bump.sh v1.9.3` (I'll do this after the review)
