### PR TITLE
Replace links with networks in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,12 @@ services:
         published: 3000
         protocol: tcp
         mode: host
-    links:
-      - db
     volumes:
       # Wherever the config file lives, root by default
       - ./backend/config.yaml:/config/incident-bot/config.yaml
+    networks:
+      - inc_bot_network
+
   db:
     image: postgres:13
     command:
@@ -54,3 +55,9 @@ services:
       POSTGRES_USER: 'incident_bot'
     ports:
       - 5432:5432
+    networks:
+      - inc_bot_network
+
+networks:
+  inc_bot_network:
+    driver: bridge


### PR DESCRIPTION
## Describe your changes

Links are [deprecated](https://docs.docker.com/network/links/) in docker and not supported in podman. This commit replaces them with networks.

## Issue number and link

## Checklist before requesting a review

- [x] I have properly bumped all version refs by running `./scripts/version-bump.sh v<new>` from project root - for example `./scripts/version-bump.sh v1.9.3`
